### PR TITLE
chore: rename project

### DIFF
--- a/.github/workflows/GitHubUserFinder.yml
+++ b/.github/workflows/GitHubUserFinder.yml
@@ -1,4 +1,4 @@
-name: GitHubUserFinderKMM
+name: GitHubUserFinder
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# GitHubUserFinderKMM
-![GitHub Actions build status](https://github.com/kaszabimre/GitHubUserFinderKMM/actions/workflows/GitHubUserFinderKMM.yml/badge.svg)
+# GitHubUserFinder
+![GitHub Actions build status](https://github.com/kaszabimre/GitHubUserFinder/actions/workflows/GitHubUserFinder.yml/badge.svg)
 
 Kotlin Multiplatform Mobile sample project with Jetpack Compose and SwiftUI
 
@@ -28,12 +28,12 @@ Android | iOS
 - Common tests
 - Dark mode
 - Automated dependency update with Renovate
-- GitHub Actions config:  [GitHubUserFinderKMM.yml](https://github.com/kaszabimre/GitHubUserFinderKMM/blob/main/.github/workflows/GitHubUserFinderKMM.yml)
+- GitHub Actions config:  [GitHubUserFinder.yml](https://github.com/kaszabimre/GitHubUserFinder/blob/main/.github/workflows/GitHubUserFinder.yml)
 - [GitHub API](https://docs.github.com/en/rest/search#search-users)
 - Coverage report (kover)
 
 ### Libraries
-> Check [Dependencies.kt](https://github.com/kaszabimre/GitHubUserFinderKMM/blob/main/buildSrc/src/main/java/Dependencies.kt) for more details
+> Check [Dependencies.kt](https://github.com/kaszabimre/GitHubUserFinder/blob/main/buildSrc/src/main/java/Dependencies.kt) for more details
 
 - 🌎 [Ktor](https://github.com/ktorio/ktor) - Network
   [![GitHub Repo stars](https://img.shields.io/github/stars/ktorio/ktor)](https://github.com/ktorio/ktor)
@@ -45,7 +45,7 @@ Android | iOS
   [![GitHub Repo stars](https://img.shields.io/github/stars/touchlab/Kermit)](https://github.com/touchlab/Kermit)
 - 🎨 [moko resources](https://github.com/icerockdev/moko-resources) - Shared resources
   [![GitHub Repo stars](https://img.shields.io/github/stars/icerockdev/moko-resources)](https://github.com/icerockdev/moko-resources)
-- 🚦 Testing - Common unit tests in `shared` module with [MockHttpClient](https://github.com/kaszabimre/GitHubUserFinderKMM/blob/main/shared/src/commonTest/kotlin/io/imrekaszab/githubuserfinder/MockHttpClient.kt)
+- 🚦 Testing - Common unit tests in `shared` module with [MockHttpClient](https://github.com/kaszabimre/GitHubUserFinder/blob/main/shared/src/commonTest/kotlin/io/imrekaszab/githubuserfinder/MockHttpClient.kt)
 - 🔍 Linter & formatter
     - [Detekt](https://github.com/detekt/detekt) - `shared + Android`
       ![GitHub Repo stars](https://img.shields.io/github/stars/detekt/Detekt)
@@ -54,7 +54,7 @@ Android | iOS
        ```
     - [Swiftlint](https://github.com/realm/SwiftLint) - `iOS`
       ![GitHub Repo stars](https://img.shields.io/github/stars/realm/SwiftLint)
-        - [Rules in swiftlint.yaml](https://github.com/kaszabimre/GitHubUserFinderKMM/blob/main/iosApp/.swiftlint.yml)
+        - [Rules in swiftlint.yaml](https://github.com/kaszabimre/GitHubUserFinder/blob/main/iosApp/.swiftlint.yml)
        ```
        swiftlint --fix
        ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ targetSdk = "34"
 javaTargetCompatibility = "17"
 javaSourceCompatibility = "11"
 
-agp = "8.2.0-beta06"
+agp = "8.2.0-alpha15"
 kotlin = "1.9.10"
 kotlinCoroutines = "1.7.3"
 kotlinDate = "0.4.1"

--- a/shared/src/commonMain/kotlin/io/imrekaszab/githubuserfinder/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/io/imrekaszab/githubuserfinder/di/Koin.kt
@@ -80,7 +80,7 @@ internal val factoryModule = module {
     val baseLogger =
         Logger(
             config = StaticConfig(logWriterList = listOf(platformLogWriter())),
-            "GitHubUserFinderKMM"
+            "GitHubUserFinder"
         )
     factory { (tag: String?) -> if (tag != null) baseLogger.withTag(tag) else baseLogger }
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes for Pull Request**

- Refactor: Renamed the project from "GitHubUserFinderKMM" to "GitHubUserFinder". This change is reflected across all files and dependencies.
- Documentation: Updated README.md to reflect the new project name and updated URLs for GitHub Actions build status badge, configuration file, and dependencies file.
- Style: Updated the logger's name in `shared/src/commonMain/kotlin/io/imrekaszab/githubuserfinder/di/Koin.kt` from "GitHubUserFinderKMM" to "GitHubUserFinder".
  
These changes do not introduce any new features or bug fixes. They are primarily focused on improving the consistency of the project naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->